### PR TITLE
feat: ABI-7845 add region to deploy params

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -85,5 +85,5 @@ runs:
         aws_access_key_id=${{inputs.AWS_ACCESS_KEY_ID_CHINA}}
         aws_secret_access_key=${{inputs.AWS_SECRET_ACCESS_KEY_CHINA}}
         EOF
-        yarn sls deploy -s ${{inputs.environment}} --aws-s3-accelerate --params="region=${{inputs.region}}"
+        yarn sls deploy -s ${{inputs.environment}} --aws-s3-accelerate --param="region=${{inputs.region}}"
         rm ~/.aws/credentials

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,7 @@ description: Deploys the selected environment
 branding: { color: blue, icon: box }
 inputs:
   environment: { description: environment name, required: true }
+  region: { description: region to deploy, required: false, default: 'eu-west-1' }
   tag: { description: tag to deploy, required: false }
   node-version: {
     description: Node version to test the lambda,
@@ -29,7 +30,7 @@ runs:
       with:
         fetch-tags: true
         ref: ${{ inputs.tag }}
-        
+
     - name: Tag info
       shell: bash
       run: |
@@ -84,5 +85,5 @@ runs:
         aws_access_key_id=${{inputs.AWS_ACCESS_KEY_ID_CHINA}}
         aws_secret_access_key=${{inputs.AWS_SECRET_ACCESS_KEY_CHINA}}
         EOF
-        yarn sls deploy -s ${{inputs.environment}} --aws-s3-accelerate
+        yarn sls deploy -s ${{inputs.environment}} --aws-s3-accelerate --params="region=${{inputs.region}}"
         rm ~/.aws/credentials


### PR DESCRIPTION
In order to write more scalable deploy scripts, region is added as a param to the `sls deploy` script. This param won't affect to projects that don't use it but is needed with new deployment scripts in other regions (Hong Kong is the first)